### PR TITLE
fix: error not propagated in Distributed Consumer

### DIFF
--- a/src/consumer/distributed.consumer.ts
+++ b/src/consumer/distributed.consumer.ts
@@ -104,7 +104,7 @@ export class DistributedConsumer {
               Log.create(
                 `Some error occurred in channel [${channel.config.name}]`,
                 {
-                  error: e,
+                  error: e instanceof Error ? e.message : String(e),
                   message: JSON.stringify(consumerMessage.message),
                   routingKey: consumerMessage.routingKey,
                 },


### PR DESCRIPTION
Hello,

I've noticed that the detail of the error is swallowed in the current implementation

Currently:
```
{"context":"MessagingModule","logMessage":"Some error occurred in channel [pubsub-command]","metadata":{"error":{},"message":"{\"foo\":\"bar\"}","routingKey":"my_app_command.create_user"}}
```

With the fix:

```
{"context":"MessagingModule","logMessage":"Some error occurred in channel [pubsub-command]","metadata":{"error":"There is no handlers for this routing key: [my_app_command.create_user]","message":"{\"foo\":\"bar\"}","routingKey":"my_app_command.create_user"}}
```

_Note: There are many ways to solve this problem, but I've chosen one of the simplest and safest at the same time_

