### PR TITLE
feat: add custom logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,19 +322,58 @@ export class CustomExceptionListener implements ExceptionListener {
 }
 ```
 
+---
+
+## 📝 Custom Logger
+
+By default, the messaging system uses Nest’s built-in `NestLogger` for logging.  
+However, you can plug in your own **custom logger** to gain more control over how messages and errors are recorded.
+
+A custom logger must implement the interface `MessagingLogger` interface:
+
+### Providing a custom logger
+
+When configuring the **messaging module**, you can pass your own logger instance via options `customLogger`.
+```ts
+@Module({
+  imports: [
+    MessagingModule.forRoot({
+      customLogger: new MyCustomLogger(),
+       ...
+    }),
+  ],
+})
+export class AppModule {}
+```
+or if you defined it as provider
+```ts
+@Module({
+  imports: [
+    MessagingModule.forRoot({
+      customLogger: MyCustomLogger,
+       ...
+    }),
+  ],
+   providers: [
+      MyCustomLogger,
+   ],
+})
+export class AppModule {}
+```
+
 ## Configuration options
 Here’s a table with the documentation for the `MessagingModule.forRoot` configuration you requested, breaking it into **buses**, **channels** (with descriptions of both channels), and their respective properties, descriptions, and default values:
 
 ### `MessagingModule.forRoot` Configuration
 <br>
 
-| **Property**   | **Description**                                                        | **Default Value**             |
-|----------------|------------------------------------------------------------------------|-------------------------------|
-| **`buses`**    | Array of message buses that define routing and processing of messages. | `[]` (empty array by default) |
-| **`channels`** | Array of channel configurations used by the message buses.             | `[]` (empty array by default) |
-| **`debug`**    | Enables or disables debug mode for logging additional messages.        | `false`                       |
-| **`logging`**  | Enables or disables logging for bus activity (e.g., message dispatch). | `true`                        |
-
+| **Property**       | **Description**                                                                  | **Default Value**             |
+|--------------------|----------------------------------------------------------------------------------|-------------------------------|
+| **`buses`**        | Array of message buses that define routing and processing of messages.           | `[]` (empty array by default) |
+| **`channels`**     | Array of channel configurations used by the message buses.                       | `[]` (empty array by default) |
+| **`debug`**        | Enables or disables debug mode for logging additional messages.                  | `false`                       |
+| **`logging`**      | Enables or disables logging for bus activity (e.g., message dispatch).           | `true`                        |
+| **`customLogger`** | Instance of a class implements `MessagingLogger` for custom logging integration. | `NestLogger`                  |
 ---
 
 ### Buses

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestjstools/messaging",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "description": "Simplifies asynchronous and synchronous message handling with support for buses, handlers, channels, and consumers. Build scalable, decoupled applications with ease and reliability.",
   "author": "Sebastian Iwanczyszyn",
   "license": "MIT",

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import { ObjectForwardMessageNormalizer } from './normalizer/object-forward-mess
 import { Type } from '@nestjs/common';
 import { DynamicModule } from '@nestjs/common/interfaces/modules/dynamic-module.interface';
 import { ForwardReference } from '@nestjs/common/interfaces/modules/forward-reference.interface';
+import { MessagingLogger } from './logger/messaging-logger';
 
 export type DefineChannels = ChannelConfig[];
 
@@ -162,4 +163,5 @@ export interface MandatoryMessagingModuleOptions {
   debug?: boolean;
   logging?: boolean;
   global?: boolean;
+  customLogger?: MessagingLogger|object;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,3 +28,6 @@ export * from './normalizer/message-normalizer';
 export * from './exception-listener/exception-listener';
 export * from './exception-listener/exception-context';
 export * from './exception/handlers.exception';
+export * from './logger/log';
+export * from './logger/messaging-logger';
+export * from './logger/nest-logger';

--- a/test/unit/channel/channel.registry.spec.ts
+++ b/test/unit/channel/channel.registry.spec.ts
@@ -1,12 +1,12 @@
 import { ChannelRegistry } from '../../../src/channel/channel.registry';
-import { MessagingLogger } from '../../../src/logger/messaging-logger';
+import { IMessagingLogger } from '../../../src/logger/i-messaging-logger';
 import { Channel } from '../../../src';
 import { MessagingException } from '../../../src/exception/messaging.exception';
 import { Logger } from '@nestjs/common';
 
 describe('ChannelRegistry', () => {
   let registry: ChannelRegistry;
-  let mockLogger: MessagingLogger;
+  let mockLogger: IMessagingLogger;
   let mockChannel: Channel<any>;
 
   beforeEach(() => {


### PR DESCRIPTION
* Introduced `customLogger` option in `MessagingModule.forRoot(...)`.
* `customLogger` must be an **instance of a class extending `MessagingLogger`**.
* If a valid instance is provided → injected as the logger.
* If no `customLogger` is provided → falls back to Nest’s built-in `NestLogger`.
* If an invalid value is provided (not an instance of `MessagingLogger`) → the module will **throw an exception at startup**.
* Updated documentation